### PR TITLE
Add support for onSingleTapConfirmed

### DIFF
--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -22,6 +22,7 @@ export default class TransformableImage extends Component {
     enableTransform: PropTypes.bool,
     enableScale: PropTypes.bool,
     enableTranslate: PropTypes.bool,
+    onSingleTapConfirmed: PropTypes.func,
     onTransformGestureReleased: PropTypes.func,
     onViewTransformed: PropTypes.func
   };
@@ -93,6 +94,7 @@ export default class TransformableImage extends Component {
         enableResistance={true}
         onTransformGestureReleased={this.props.onTransformGestureReleased}
         onViewTransformed={this.props.onViewTransformed}
+        onSingleTapConfirmed={this.props.onSingleTapConfirmed}
         maxScale={maxScale}
         contentAspectRatio={contentAspectRatio}
         onLayout={this.onLayout.bind(this)}


### PR DESCRIPTION
I use your library to show image in <Modal/> and I want to have an action to close the modal (single tap in my case).

Corresponding PR: https://github.com/ldn0x7dc/react-native-view-transformer/pull/4
