### PR TITLE
Update TransformableImage.js

### DIFF
--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -23,7 +23,8 @@ export default class TransformableImage extends Component {
     enableScale: PropTypes.bool,
     enableTranslate: PropTypes.bool,
     onTransformGestureReleased: PropTypes.func,
-    onViewTransformed: PropTypes.func
+    onViewTransformed: PropTypes.func,
+    minScale: PropTypes.number
   };
 
   static defaultProps = {
@@ -63,6 +64,7 @@ export default class TransformableImage extends Component {
     let maxScale = 1;
     let contentAspectRatio = undefined;
     let width, height; //pixels
+    const { minScale } = this.props;
 
     if (this.props.pixels) {
       //if provided via props
@@ -78,10 +80,11 @@ export default class TransformableImage extends Component {
       contentAspectRatio = width / height;
       if (this.state.width && this.state.height) {
         maxScale = Math.max(width / this.state.width, height / this.state.height);
-        maxScale = Math.max(1, maxScale);
+        if(minScale){
+            maxScale = Math.max(minScale, maxScale);
+        }
       }
     }
-
 
     return (
       <ViewTransformer


### PR DESCRIPTION
Add a minScale prop makes the image scales  minScale at least.
In the case of that the Image size is same with the screen size， when i double-tap the image,
i hope the image scale to the minScale instead of nothing happend.
