### PR TITLE
Added automaticInitialCoverScale

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,15 @@ render() {
   }
 ```
 
-You can provide `enableTransform`, `enableScale` and `enableTranslate`  props to control corresponding features.
+You can provide `enableTransform`, `enableScale`, `enableTranslate` and `enableLimits`  props to control corresponding features.
 
 #### Other props
 
 * `onTransformGestureReleased` and `onViewTransformed`: 
 
 ​	inherited from [react-native-view-transformer](https://github.com/ldn0x7dc/react-native-view-transformer)
+
+* `automaticCoverInitialScale`: When set to `true` makes the Image look like if `resizeMode="cover"`
 
 ### Attention
 

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -48,7 +48,7 @@ export default class TransformableImage extends Component {
       initialScale: props.initialScale,
       imageLoaded: false,
       pixels: undefined,
-      keyAcumulator: 1
+      keyAccumulator: 1
     };
   }
 
@@ -60,7 +60,7 @@ export default class TransformableImage extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (!sameSource(this.props.source, nextProps.source)) {
-      this.setState({ keyAcumulator: this.state.keyAcumulator + 1 })
+      //this.setState({ keyAccumulator: this.state.keyAccumulator + 1 })
 
       // Make sure new image resets its initial cover scale
       if (nextProps.automaticInitialCoverScale) {
@@ -95,8 +95,22 @@ export default class TransformableImage extends Component {
       }
     }
 
+    var child = null
     if (initialScale == null && this.props.automaticInitialCoverScale) {
-      return <View onLayout={this.onLayout.bind(this)} style={this.props.style} ></View>
+      child = (
+        <View onLayout={this.onLayout.bind(this)} style={this.props.style}></View>
+      )
+    } else {
+      child = (
+        <Image
+          {...this.props}
+          style={[this.props.style, {backgroundColor: 'transparent'}]}
+          resizeMode={'contain'}
+          onLoadStart={this.onLoadStart.bind(this)}
+          onLoad={this.onLoad.bind(this)}
+          capInsets={{left: 0.1, top: 0.1, right: 0.1, bottom: 0.1}} //on iOS, use capInsets to avoid image downsampling
+        />
+      )
     }
 
     return (
@@ -116,14 +130,7 @@ export default class TransformableImage extends Component {
         onLayout={this.onLayout.bind(this)}
         style={this.props.style}
       >
-        <Image
-          {...this.props}
-          style={[this.props.style, {backgroundColor: 'transparent'}]}
-          resizeMode={'contain'}
-          onLoadStart={this.onLoadStart.bind(this)}
-          onLoad={this.onLoad.bind(this)}
-          capInsets={{left: 0.1, top: 0.1, right: 0.1, bottom: 0.1}} //on iOS, use capInsets to avoid image downsampling
-        />
+        {child}
       </ViewTransformer>
     );
   }
@@ -195,7 +202,9 @@ export default class TransformableImage extends Component {
       }
     }
 
-    let newState = { initialScale: initialScale }
+    let newState = {
+      initialScale: initialScale,
+    }
     if (this.state.updateTransform) {
       this.refs['viewTransformer'].updateTransform({
         scale: initialScale,

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -52,6 +52,12 @@ export default class TransformableImage extends Component {
     };
   }
 
+  componentWillMount() {
+    if (!this.props.pixels) {
+      this.getImageSize(this.props.source);
+    }
+  }
+
   componentWillReceiveProps(nextProps) {
     if (!sameSource(this.props.source, nextProps.source)) {
       this.setState({ keyAcumulator: this.state.keyAccumulator + 1 })
@@ -231,6 +237,41 @@ export default class TransformableImage extends Component {
       }
 
       this.setState(newState);
+    }
+  }
+
+  getImageSize(source) {
+    if(!source) return;
+
+    DEV && console.log('getImageSize...' + JSON.stringify(source));
+
+    if (typeof Image.getSize === 'function') {
+      if (source && source.uri) {
+        Image.getSize(
+          source.uri,
+          (width, height) => {
+            DEV && console.log('getImageSize...width=' + width + ', height=' + height);
+            if (width && height) {
+              this.setState(
+                {pixels: {width, height}},
+                () => {
+                  this.setInitialCoverScale(this.state.width, this.state.height)
+                }
+              );
+
+              if (this.props.onSizeFound) {
+                this.props.onSizeFound({width, height});
+              }
+            }
+          },
+          (error) => {
+            console.error('getImageSize...error=' + JSON.stringify(error) + ', source=' + JSON.stringify(source));
+          })
+      } else {
+        console.warn('getImageSize...please provide pixels prop for local images');
+      }
+    } else {
+      console.warn('getImageSize...Image.getSize function not available before react-native v0.28');
     }
   }
 

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Image, View, PixelRatio } from 'react-native';
 
 import ViewTransformer from 'react-native-view-transformer';

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React, { Component, PropTypes } from 'react';
-import { Image } from 'react-native';
+import { Image, View, PixelRatio } from 'react-native';
 
 import ViewTransformer from 'react-native-view-transformer';
 
@@ -22,6 +22,8 @@ export default class TransformableImage extends Component {
     enableTransform: PropTypes.bool,
     enableScale: PropTypes.bool,
     enableTranslate: PropTypes.bool,
+    initialScale: PropTypes.number,
+    automaticInitialCoverScale: PropTypes.bool,
     onTransformGestureReleased: PropTypes.func,
     onViewTransformed: PropTypes.func
   };
@@ -29,16 +31,21 @@ export default class TransformableImage extends Component {
   static defaultProps = {
     enableTransform: true,
     enableScale: true,
-    enableTranslate: true
+    enableTranslate: true,
+    initialScale: null,
+    updateTransform: false,
+    automaticInitialCoverScale: false,
   };
 
   constructor(props) {
     super(props);
 
+    this.setInitialCoverScale = this.setInitialCoverScale.bind(this);
     this.state = {
       width: 0,
       height: 0,
 
+      initialScale: props.initialScale,
       imageLoaded: false,
       pixels: undefined,
       keyAcumulator: 1
@@ -53,35 +60,44 @@ export default class TransformableImage extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (!sameSource(this.props.source, nextProps.source)) {
-      //image source changed, clear last image's pixels info if any
-      this.setState({pixels: undefined, keyAcumulator: this.state.keyAcumulator + 1})
-      this.getImageSize(nextProps.source);
+      this.setState({ keyAcumulator: this.state.keyAcumulator + 1 })
+
+      // Make sure new image resets its initial cover scale
+      if (nextProps.automaticInitialCoverScale) {
+        this.setState({ updateTransform: true })
+      }
+
+      // image source changed, clear last image's pixels info if any
+      if (typeof nextProps.pixels == 'undefined') {
+        this.getImageSize(nextProps.source);
+      } else {
+        this.setInitialCoverScale(this.state.width, this.state.height);
+      }
     }
   }
 
   render() {
     let maxScale = 1;
     let contentAspectRatio = undefined;
-    let width, height; //pixels
-
-    if (this.props.pixels) {
-      //if provided via props
-      width = this.props.pixels.width;
-      height = this.props.pixels.height;
-    } else if (this.state.pixels) {
-      //if got using Image.getSize()
-      width = this.state.pixels.width;
-      height = this.state.pixels.height;
-    }
+    let { width, height } = this.getWidthAndHeight();
+    let initialScale = this.state.initialScale;
 
     if (width && height) {
       contentAspectRatio = width / height;
+
       if (this.state.width && this.state.height) {
         maxScale = Math.max(width / this.state.width, height / this.state.height);
         maxScale = Math.max(1, maxScale);
       }
+
+      if (maxScale < initialScale && initialScale != null) {
+        maxScale = initialScale + 2
+      }
     }
 
+    if (initialScale == null && this.props.automaticInitialCoverScale) {
+      return <View onLayout={this.onLayout.bind(this)} style={this.props.style} ></View>
+    }
 
     return (
       <ViewTransformer
@@ -91,12 +107,15 @@ export default class TransformableImage extends Component {
         enableScale={this.props.enableScale}
         enableTranslate={this.props.enableTranslate}
         enableResistance={true}
+        enableLimits={true}
         onTransformGestureReleased={this.props.onTransformGestureReleased}
         onViewTransformed={this.props.onViewTransformed}
         maxScale={maxScale}
+        initialScale={initialScale == null ? 1 : initialScale}
         contentAspectRatio={contentAspectRatio}
         onLayout={this.onLayout.bind(this)}
-        style={this.props.style}>
+        style={this.props.style}
+      >
         <Image
           {...this.props}
           style={[this.props.style, {backgroundColor: 'transparent'}]}
@@ -123,13 +142,87 @@ export default class TransformableImage extends Component {
     });
   }
 
-  onLayout(e) {
-    let {width, height} = e.nativeEvent.layout;
-    if (this.state.width !== width || this.state.height !== height) {
-      this.setState({
-        width: width,
-        height: height
+  getWidthAndHeight() {
+    let width, height;
+
+    if (this.props.pixels) {
+      // If provided via props
+      width = this.props.pixels.width;
+      height = this.props.pixels.height;
+    } else if (this.state.pixels) {
+      // If got using Image.getSize()
+      width = this.state.pixels.width;
+      height = this.state.pixels.height;
+    }
+
+    return { width, height }
+  }
+
+  setInitialCoverScale(viewWidth, viewHeight) {
+    // automatic cover scale using a rule of three
+    let { width, height } = this.getWidthAndHeight();
+
+    if (
+      viewWidth == 0 || viewHeight == 0 ||
+      typeof width == 'undefined' || typeof height == 'undefined'
+    ) {
+      return
+    }
+
+    let initialScale = this.props.initialScale;
+
+    viewHeight = PixelRatio.getPixelSizeForLayoutSize(viewHeight)
+    viewWidth = PixelRatio.getPixelSizeForLayoutSize(viewWidth)
+
+    if (this.props.automaticInitialCoverScale) {
+
+      if (height > width) {
+        var proportionalImageHeight = (viewHeight * width) / viewWidth;
+
+        if (proportionalImageHeight > height) {
+          initialScale = proportionalImageHeight / height;
+        } else {
+          initialScale = height / proportionalImageHeight;
+        }
+      } else {
+        var proportionalImageWidth = (viewWidth * height) / viewHeight;
+
+        if (proportionalImageWidth > width) {
+          initialScale = proportionalImageWidth / width;
+        } else {
+          initialScale = width / proportionalImageWidth;
+        }
+      }
+    }
+
+    let newState = { initialScale: initialScale }
+    if (this.state.updateTransform) {
+      this.refs['viewTransformer'].updateTransform({
+        scale: initialScale,
+        translateX: 0,
+        translateY: 0,
       });
+      newState['updateTransform'] = false
+    }
+
+    this.setState(newState)
+    return initialScale;
+  }
+
+  onLayout(e) {
+    let { width, height } = e.nativeEvent.layout;
+
+    if (this.state.width !== width || this.state.height !== height) {
+      let newState = {
+        width: width,
+        height: height,
+      };
+
+      if (this.state.initialScale == null && this.props.automaticInitialCoverScale) {
+        this.setInitialCoverScale(width, height);
+      }
+
+      this.setState(newState);
     }
   }
 
@@ -145,10 +238,15 @@ export default class TransformableImage extends Component {
           (width, height) => {
             DEV && console.log('getImageSize...width=' + width + ', height=' + height);
             if (width && height) {
-              if(this.state.pixels && this.state.pixels.width === width && this.state.pixels.height === height) {
-                //no need to update state
-              } else {
-                this.setState({pixels: {width, height}});
+              this.setState(
+                {pixels: {width, height}},
+                () => {
+                  this.setInitialCoverScale(this.state.width, this.state.height)
+                }
+              );
+
+              if (this.props.onSizeFound) {
+                this.props.onSizeFound({width, height});
               }
             }
           },

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import FastImage from 'react-native-fast-image'
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Image, View, PixelRatio } from 'react-native';
@@ -110,7 +112,7 @@ export default class TransformableImage extends Component {
       )
     } else {
       child = (
-        <Image
+        <FastImage
           {...this.props}
           style={[this.props.style, {backgroundColor: 'transparent'}]}
           resizeMode={'contain'}

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -52,15 +52,9 @@ export default class TransformableImage extends Component {
     };
   }
 
-  componentWillMount() {
-    if (!this.props.pixels) {
-      this.getImageSize(this.props.source);
-    }
-  }
-
   componentWillReceiveProps(nextProps) {
     if (!sameSource(this.props.source, nextProps.source)) {
-      //this.setState({ keyAccumulator: this.state.keyAccumulator + 1 })
+      this.setState({ keyAcumulator: this.state.keyAccumulator + 1 })
 
       // Make sure new image resets its initial cover scale
       if (nextProps.automaticInitialCoverScale) {
@@ -68,11 +62,18 @@ export default class TransformableImage extends Component {
       }
 
       // image source changed, clear last image's pixels info if any
-      if (typeof nextProps.pixels == 'undefined') {
-        this.getImageSize(nextProps.source);
-      } else {
-        this.setInitialCoverScale(this.state.width, this.state.height);
-      }
+      this.setInitialCoverScale(this.state.width, this.state.height);
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    // When we are given the image size and have to calculate initialScale
+    if (
+      this.props.pixels != prevProps.pixels &&
+      this.state.initialScale == null &&
+      this.props.automaticInitialCoverScale
+    ) {
+      this.setInitialCoverScale(this.state.width, this.state.height);
     }
   }
 
@@ -202,9 +203,7 @@ export default class TransformableImage extends Component {
       }
     }
 
-    let newState = {
-      initialScale: initialScale,
-    }
+    let newState = { initialScale: initialScale }
     if (this.state.updateTransform) {
       this.refs['viewTransformer'].updateTransform({
         scale: initialScale,
@@ -232,41 +231,6 @@ export default class TransformableImage extends Component {
       }
 
       this.setState(newState);
-    }
-  }
-
-  getImageSize(source) {
-    if(!source) return;
-
-    DEV && console.log('getImageSize...' + JSON.stringify(source));
-
-    if (typeof Image.getSize === 'function') {
-      if (source && source.uri) {
-        Image.getSize(
-          source.uri,
-          (width, height) => {
-            DEV && console.log('getImageSize...width=' + width + ', height=' + height);
-            if (width && height) {
-              this.setState(
-                {pixels: {width, height}},
-                () => {
-                  this.setInitialCoverScale(this.state.width, this.state.height)
-                }
-              );
-
-              if (this.props.onSizeFound) {
-                this.props.onSizeFound({width, height});
-              }
-            }
-          },
-          (error) => {
-            console.error('getImageSize...error=' + JSON.stringify(error) + ', source=' + JSON.stringify(source));
-          })
-      } else {
-        console.warn('getImageSize...please provide pixels prop for local images');
-      }
-    } else {
-      console.warn('getImageSize...Image.getSize function not available before react-native v0.28');
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/ldn0x7dc/react-native-transformable-image#readme",
   "dependencies": {
-    "react-native-view-transformer": "git+https://github.com/maraujop/react-native-view-transformer.git#feature-enableLimits"
+    "react-native-view-transformer": "git+https://github.com/maraujop/react-native-view-transformer.git#755dfcd09ea01d75244728e69c63d9c89ef69a5c"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/ldn0x7dc/react-native-transformable-image#readme",
   "dependencies": {
-    "react-native-view-transformer": "0.0.28"
+    "react-native-view-transformer": "git+https://github.com/maraujop/react-native-view-transformer.git#feature-enableLimits"
   }
 }


### PR DESCRIPTION
In this case I needed my images to behave like if their resizeMode was set to `cover` and to be honest, if you agree, instead of adding a new prop like `automaticInitialCoverScale` I think it would be better to make `resizeMode` work, as that's the one people would expect to change in the original Image component and they already understand it.

When this prop is activated the image is rendered like if `resizeMode` was set to `cover`.

This PR also allows to use `enableLimits` from this other PR https://github.com/ldn0x7dc/react-native-view-transformer/pull/5 and it also relies on `initialScale` prop from that PR to work. I could make them non dependent if you want me to.

Maybe it would be nice to pass <ViewTransformer {...this.props}> too, so that it would not be necessary to make PRs dependent. 

Thanks, cheers
Miguel
