### PR TITLE
Delegating all possible props to ViewTransformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -83,21 +83,20 @@ export default class TransformableImage extends Component {
       }
     }
 
+    const viewTransformerDelegation = Object.keys(ViewTransformer.propTypes).reduce(
+      (acc, prop) => (this.props[prop] ? { ...acc, [prop]: this.props[prop] } : acc), {}
+    );
 
     return (
       <ViewTransformer
         ref='viewTransformer'
         key={'viewTransformer#' + this.state.keyAccumulator} //when image source changes, we should use a different node to avoid reusing previous transform state
-        enableTransform={this.props.enableTransform && this.state.imageLoaded} //disable transform until image is loaded
-        enableScale={this.props.enableScale}
-        enableTranslate={this.props.enableTranslate}
         enableResistance={true}
-        onTransformGestureReleased={this.props.onTransformGestureReleased}
-        onViewTransformed={this.props.onViewTransformed}
-        onSingleTapConfirmed={this.props.onSingleTapConfirmed}
         maxScale={maxScale}
         contentAspectRatio={contentAspectRatio}
         onLayout={this.onLayout.bind(this)}
+        {...viewTransformerDelegation}
+        enableTransform={this.props.enableTransform && this.state.imageLoaded} //disable transform until image is loaded
         style={this.props.style}>
         <Image
           {...this.props}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/ldn0x7dc/react-native-transformable-image#readme",
   "dependencies": {
-    "react-native-view-transformer": "0.0.28"
+    "react-native-view-transformer": "git://github.com/ldn0x7dc/react-native-view-transformer#f7e028b6566022deac4e523052e74c2c63a4af7e"
   }
 }


### PR DESCRIPTION
First of all thanks for the project, it is really helpful! It saved me a lot of time.

As you said, this project is a layer over https://github.com/ldn0x7dc/react-native-view-transformer so it can be painful to keep both interfaces in sync. This commit delegates to view transformer all possible props.

The reason I need this modification is that to fit the UX I desire I need to modify maxScale and  maxOverScrollDistance. View transformer is so powerful, I believe exposing its full interface will be a great improvement to react-native-transformable-image users.

Cheers!