### PR TITLE
Add on onSingleTap and onDoubleTap callback props

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.idea/
+.gitignore
+
+Demo/

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -22,7 +22,21 @@ export default class TransformableImage extends Component {
     enableTransform: PropTypes.bool,
     enableScale: PropTypes.bool,
     enableTranslate: PropTypes.bool,
+    /**
+     * Callback after a single tap (includes first and second tap of double-tap)
+     */
+    onSingleTap: PropTypes.func,
+    /**
+     * Callback after a single tap which is not part of a double-tap
+     */
     onSingleTapConfirmed: PropTypes.func,
+    /**
+     * Callback on a double tap (if supplied, it overwrites the default scaling behavior)
+     *
+     * The first two arguments of the callback are the x- and y-coordinates of the
+     * finger while tapping, respectively.
+     */
+    onDoubleTap: PropTypes.func,
     onTransformGestureReleased: PropTypes.func,
     onViewTransformed: PropTypes.func
   };
@@ -32,7 +46,9 @@ export default class TransformableImage extends Component {
     enableTransform: true,
     enableScale: true,
     enableTranslate: true,
+    onSingleTap: undefined,
     onSingleTapConfirmed: undefined,
+    onDoubleTap: undefined,
     onTransformGestureReleased: undefined,
     onViewTransformed: undefined,
   };
@@ -98,7 +114,9 @@ export default class TransformableImage extends Component {
         enableResistance={true}
         onTransformGestureReleased={this.props.onTransformGestureReleased}
         onViewTransformed={this.props.onViewTransformed}
+        onSingleTap={this.props.onSingleTap}
         onSingleTapConfirmed={this.props.onSingleTapConfirmed}
+        onDoubleTap={this.props.onDoubleTap}
         maxScale={maxScale}
         contentAspectRatio={contentAspectRatio}
         onLayout={this.onLayout.bind(this)}

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -28,9 +28,13 @@ export default class TransformableImage extends Component {
   };
 
   static defaultProps = {
+    pixels: undefined,
     enableTransform: true,
     enableScale: true,
-    enableTranslate: true
+    enableTranslate: true,
+    onSingleTapConfirmed: undefined,
+    onTransformGestureReleased: undefined,
+    onViewTransformed: undefined,
   };
 
   constructor(props) {


### PR DESCRIPTION
These props deliver the new props added in https://github.com/ldn0x7dc/react-native-view-transformer/pull/9 to this Component.

* I also add an `.npmignore` file so that the Demo is not anymore included in npm builds.
* Furthermore I explicitly set the default values of not required props to undefined.