### PR TITLE
Update prop types dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Image } from 'react-native';
 
 import ViewTransformer from 'react-native-view-transformer';

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/ldn0x7dc/react-native-transformable-image#readme",
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react-native-view-transformer": "0.0.28"
   }
 }


### PR DESCRIPTION
- Adds prop-types npm package.
- Deprecates usage of React.PropTypes from 'react' npm package.
- Adds missing .gitignore file with node_modules ignore